### PR TITLE
Significantly improve memory usage when rendering zoom levels 

### DIFF
--- a/PapyrusCs/Strategies/Dataflow/DataFlowStrategy.cs
+++ b/PapyrusCs/Strategies/Dataflow/DataFlowStrategy.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -212,6 +213,10 @@ namespace PapyrusCs.Strategies.Dataflow
 
             while (sourceZoomLevel > NewLastZoomLevel)
             {
+                // Force garbage collection (may not be necessary)
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
                 var destDiameter = sourceDiameter / 2;
                 var sourceZoom = sourceZoomLevel;
                 var destZoom = sourceZoomLevel - 1;
@@ -278,6 +283,12 @@ namespace PapyrusCs.Strategies.Dataflow
                                     }
 
                                     SaveBitmap(destZoom, x / 2, z / 2, isUpdate, bfinal);
+                                }
+
+                                // Dispose of any bitmaps, releasing memory
+                                foreach (var bitmap in new[] { b1, b2, b3, b4, bfinal }.OfType<Bitmap>())
+                                {
+                                    bitmap.Dispose();
                                 }
                             }
                         }


### PR DESCRIPTION
Disposing of bitmaps made the biggest impact here.  They must have been hanging on to file locks or something.  Right now everything is bitmap in this area.  In the future if you add other image types, it would probably be good to add IDisposable to your interface, and dispose of all images instead of just bitmaps.

I also added code to force garbage collection, which looks like it helps a little.  I think it is frowned upon to try to manage the garbage collector, but since we know this is the peak memory usage point, I think it's okay to do it here.

(Fixes #12) (Fixes #20)