### PR TITLE
Add player markers

### DIFF
--- a/Maploader/World/World.cs
+++ b/Maploader/World/World.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using fNbt;
 using leveldb_sharp_std;
@@ -181,6 +182,47 @@ namespace Maploader.World
                     if (key != null)
                         yield return key;
                 }
+            }
+        }
+
+        public IEnumerable<(Guid Uuid, string Name, int DimensionId, float[] Position)> GetPlayerData()
+        {
+            var playerKeyIndicator = Encoding.UTF8.GetBytes("player_server");
+
+            // Get all records whose key begins with "player_server"
+            var playerData = db
+                .Where(kvp => kvp.Key.Take(playerKeyIndicator.Length).SequenceEqual(playerKeyIndicator))
+                .Select(i => new
+                {
+                    // Parse the UUID from the key
+                    PlayerUuid = Guid.Parse(Encoding.UTF8.GetString(i.Key.Skip(playerKeyIndicator.Length + 1).ToArray())),
+                    i.Value
+                })
+                .ToList();
+
+            if (!playerData.Any())
+            {
+                yield break;
+            }
+
+            foreach (var playerNbtData in playerData)
+            {
+                using var memoryStream = new MemoryStream(playerNbtData.Value);
+
+                var nbtReader = new NbtReader(memoryStream, false);
+
+                // Example Player NBT tag contents: https://gist.github.com/barrett777/d7c02000aace08c536f13fb1d3f1cf3b
+                var playerTag = nbtReader.ReadAsTag();
+
+                yield return
+                (
+                    // This UUID different than the Minecraft Java edition UUID - I haven't been able to find a way to get a player name using this
+                    // For now, I'll just rely on users manually entering names into a JSON file on the web server
+                    Uuid: playerNbtData.PlayerUuid,
+                    Name: playerNbtData.PlayerUuid.ToString(),
+                    DimensionId: playerTag["DimensionId"].IntValue,
+                    Position: new[] { playerTag["Pos"][0].FloatValue, playerTag["Pos"][1].FloatValue, playerTag["Pos"][2].FloatValue }
+                );
             }
         }
 

--- a/Maploader/World/World.cs
+++ b/Maploader/World/World.cs
@@ -219,7 +219,7 @@ namespace Maploader.World
                     // This UUID different than the Minecraft Java edition UUID - I haven't been able to find a way to get a player name using this
                     // For now, I'll just rely on users manually entering names into a JSON file on the web server
                     Uuid: playerNbtData.PlayerUuid,
-                    Name: playerNbtData.PlayerUuid.ToString(),
+                    Name: $"Player {playerNbtData.PlayerUuid.ToString().Substring(0, 5)}",
                     DimensionId: playerTag["DimensionId"].IntValue,
                     Position: new[] { playerTag["Pos"][0].FloatValue, playerTag["Pos"][1].FloatValue, playerTag["Pos"][2].FloatValue }
                 );

--- a/PapyrusCs/Options.cs
+++ b/PapyrusCs/Options.cs
@@ -112,6 +112,9 @@ namespace PapyrusCs
         [Option("chunksperdimension", Required = false, Default = 2, HelpText = "Sets the chunks per X and Y dimension for the generated tiles. 1 => 1 chunk per tile, 2 => 4 chunks per tile and so on")]
         public int ChunksPerDimension { get; set; }
 
+        [Option("playericons", Required = false, Default = true, HelpText = "Renders player markers on the map. Player names must be manually entered. After running, edit '/map/playersData.js' text file to modify player names and colors.")]
+        public bool ShowPlayerIcons { get; set; }
+
 
         // Derivative options
         public bool Loaded { get; set; }

--- a/PapyrusCs/Options.cs
+++ b/PapyrusCs/Options.cs
@@ -115,6 +115,9 @@ namespace PapyrusCs
         [Option("playericons", Required = false, Default = true, HelpText = "Renders player markers on the map. Player names must be manually entered. After running, edit '/map/playersData.js' text file to modify player names and colors.")]
         public bool ShowPlayerIcons { get; set; }
 
+        [Option("render_map", Required = false, Default = true, HelpText = "Renders the map. This is the main feature of this program. Only disable this in special circumstances, such as if you want to quickly update player markers without updating the map.")]
+        public bool RenderMap { get; set; }
+
 
         // Derivative options
         public bool Loaded { get; set; }

--- a/PapyrusCs/map.thtml
+++ b/PapyrusCs/map.thtml
@@ -369,6 +369,10 @@
         {
             var player = playersData.players[playerIndex];
 
+            if (!player.visible) {
+                continue;
+            }
+
             if (player.dimensionId !== 0) {
                 // TODO: Currently I'm only adding player markers who are in the Overworld
                 // We'll want to show players depending on which dimension is being viewed
@@ -389,7 +393,7 @@
             var playerFeature = new ol.Feature({
                 geometry: new ol.geom.Point([
                     (player.position[0] * zoomRatioForMaximumZoom) / minecraftTilesAtMostZoomedInLevel,
-                    (player.position[2] * zoomRatioForMaximumZoom) / minecraftTilesAtMostZoomedInLevel
+                    (-player.position[2] * zoomRatioForMaximumZoom) / minecraftTilesAtMostZoomedInLevel
                 ])
             });
 

--- a/PapyrusCs/map.thtml
+++ b/PapyrusCs/map.thtml
@@ -9,12 +9,18 @@
     />
     <link
       rel="stylesheet"
-      href="https://openlayers.org/en/v5.3.0/css/ol.css"
+      href="https://openlayers.org/en/v6.1.1/css/ol.css"
     />
     <link
       href="https://fonts.googleapis.com/css?family=Roboto&display=swap"
       rel="stylesheet"
     />
+
+    <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css"
+		integrity="sha256-46qynGAkLSFpVbEBog43gvNhfrOj+BmwXdxFgVK/Kvc="
+		crossorigin="anonymous" />
 
     <style>
       #map {
@@ -42,7 +48,7 @@
   </head>
 
   <body margin="0" padding="0">
-    <script src="https://openlayers.org/en/v5.3.0/build/ol.js"></script>
+    <script src="https://openlayers.org/en/v6.1.1/build/ol.js"></script>
     <script
       src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
       integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
@@ -58,6 +64,8 @@
       integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
       crossorigin="anonymous"
     ></script>
+
+    <script src="playersData.js"></script>
 
     <div id="map"></div>
     <script>
@@ -165,7 +173,7 @@
               tileUrlFunction: function(tileCoord, pixelRatio, projection) {
                 const z = tileCoord[0];
                 const x = tileCoord[1];
-                const y = -tileCoord[2] - 1;
+                const y = tileCoord[2];
                 return (
                   "./" +
                   layer.folder +
@@ -353,6 +361,53 @@
 
         locationElement.innerText = "X: " + x + " Z: " + z;
       });
+
+      if (typeof(playersData) !== "undefined") {
+        var playerFeatures = [];
+
+        for (var playerIndex in playersData.players)
+        {
+            var player = playersData.players[playerIndex];
+
+            if (player.dimensionId !== 0) {
+                // TODO: Currently I'm only adding player markers who are in the Overworld
+                // We'll want to show players depending on which dimension is being viewed
+                // Maybe add a separate layer for players in each dimension
+                continue;
+            }
+
+            var style = new ol.style.Style({
+                text: new ol.style.Text({
+                    text: player.name + "\n\uf041", // map-marker
+                    font: "900 18px 'Font Awesome 5 Free'",
+                    textBaseline: "bottom",
+                    fill: new ol.style.Fill({color: player.color}),
+                    stroke: new ol.style.Stroke({color: "white", width: 2})
+                })
+            });
+
+            var playerFeature = new ol.Feature({
+                geometry: new ol.geom.Point([
+                    (player.position[0] * zoomRatioForMaximumZoom) / minecraftTilesAtMostZoomedInLevel,
+                    (player.position[2] * zoomRatioForMaximumZoom) / minecraftTilesAtMostZoomedInLevel
+                ])
+            });
+
+            playerFeature.setStyle(style);
+
+            playerFeatures.push(playerFeature);
+        }
+
+        var vectorSource = new ol.source.Vector({
+            features: playerFeatures
+        });
+
+        var vectorLayer = new ol.layer.Vector({
+            source: vectorSource
+        });
+
+        map.addLayer(vectorLayer);
+      }
     </script>
   </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,13 @@ outputdir
 |   |-dim1
 |   |-dim2
 |   |-map.html
+|   |-playersData.js
 |-update
 |   |-dim0
 |   |-dim1
 |   |-dim2
 |   |-map.html
+|   |-playersData.js
 |-chunks.sqlite
 |-chunks-backup.sqlite
 ```
@@ -92,9 +94,7 @@ Since MCBE worlds don't use the Anvil format like in the Java Edition, but rathe
 
 #### Planned
 
-- Nether/ The End support
 - Isometric renders
-- Auto-Updating renders
 
 ## Installation
 Otherwise, just grab one of the [pre-built binaries](https://github.com/mjungnickel18/papyruscs/releases).
@@ -179,6 +179,12 @@ For Linux: give the extracted PapyrusCs file execution rights! See installation 
   --use_leaflet_legacy            (Default: false) Use the legacy leaflet.js map renderer instead of the new
                                   OpenLayers version
                                   
+  --playericons                   (Default: true) Renders player markers on the map. Player names must be manually entered.
+                                  After running, edit '/map/playersData.js' text file to modify player names and colors.
+                                  Updated player names and colors will be preserved when re-running
+								  Currently, only players on the Overworld are supported
+                                  Note: Not compatible with 'use_leaflet_legacy'
+
   --help                          Display this help screen.
 
   --version                       Display version information.

--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,10 @@ For Linux: give the extracted PapyrusCs file execution rights! See installation 
 								  Currently, only players on the Overworld are supported
                                   Note: Not compatible with 'use_leaflet_legacy'
 
+  --render_map                    (Default: true) Renders the map. This is the main feature of this program.
+                                  Only disable this in special circumstances, such as if you want to
+                                  quickly update player markers without updating the map.
+
   --help                          Display this help screen.
 
   --version                       Display version information.


### PR DESCRIPTION
Adds player markers, showing where players are on the map

Unfortunately, I'm not able to retrieve player name from the data file.  There is just a UUID identifier, and all the resources I could find online to look up a username from UUID are for the Java edition of Minecraft.

The way I've implemented it, after rendering your world, you will need to edit /maps/playersData.js and manually enter player's names.  You only have to do it once, though, and then it will be remembered.

Here's info on other data available in the player data, in case anyone else wants to add more: https://gist.github.com/barrett777/d7c02000aace08c536f13fb1d3f1cf3b.  It does have pretty much everything else, inventory, equipment, etc.

I've added a new command line option --playericons which I've set as enabled by default

I also updated OpenLayers to v6, which had one breaking change that I fixed (in tileUrlFunction)

I'm only supporting the Overworld for now.  Maybe I will add support for Nether and The End later

Fixes https://github.com/mjungnickel18/papyruscs/issues/15