### PR TITLE
Output defaults to a separate folder for each world

### DIFF
--- a/Maploader/World/World.cs
+++ b/Maploader/World/World.cs
@@ -16,6 +16,11 @@ namespace Maploader.World
     public class World
     {
         private DB db;
+        private string _dbPath;
+
+        public string WorldName { get; private set; }
+
+        public string WorldPath { get; private set; }
 
         public void Open(string pathDb)
         {
@@ -29,12 +34,39 @@ namespace Maploader.World
                 pathDb = Path.Combine(pathDb, "db");
             }
 
+            WorldPath = DbPathToWorldPath(pathDb);
+
+            LoadWorldName();
+            LoadLevelDat();
+            LoadDatabase();
+        }
+
+        private void LoadWorldName()
+        {
+            string worldNameFilePath = Path.Combine(WorldPath, "levelname.txt");
+            WorldName = File.ReadLines(worldNameFilePath).First();
+        }
+
+        private void LoadLevelDat()
+        {
+            string levelDatFilePath = Path.Combine(WorldPath, "level.dat");
+            // Process the level.dat file (NBT).
+            // Hopefully will get changes merged into CoreFNBT to allow reading this specific variation on the NBT file format.
+        }
+
+        private void LoadDatabase()
+        {
+            _dbPath = Path.Combine(WorldPath, "db");
+
             var options = new Options();
             options.Compression = CompressionType.ZlibRaw;
 
-            db = new DB(options, pathDb);
+            db = new DB(options, _dbPath);
         }
-
+        private string DbPathToWorldPath(string dbPath)
+        {
+            return Directory.GetParent(dbPath).FullName;
+        }
 
         public ChunkData GetOverworldChunkData(int x, int z)
         {

--- a/PapyrusCs/Options.cs
+++ b/PapyrusCs/Options.cs
@@ -41,7 +41,7 @@ namespace PapyrusCs
         [Option('w', "world", Required = false, HelpText = "Sets the path the Minecraft Bedrock Edition Map")]
         public string MinecraftWorld { get; set; }
 
-        [Option('o', "output", Required = false, HelpText = "Sets the output path for the generated map tiles", Default = "generatedmap")]
+        [Option('o', "output", Required = false, HelpText = "Sets the output path for the generated map tiles")]
         public string OutputPath { get; set; }
 
         [Option("htmlfile", Required = false, HelpText = "Sets name of html map file", Default = "map.html")]

--- a/PapyrusCs/Program.cs
+++ b/PapyrusCs/Program.cs
@@ -199,7 +199,17 @@ namespace PapyrusCs
                 int chunksPerDimension = options.ChunksPerDimension;
                 int tileSize = chunkSize * chunksPerDimension;
                 Console.WriteLine($"Tilesize is {tileSize}x{tileSize}");
-                Directory.CreateDirectory(options.OutputPath);
+                
+                if (String.IsNullOrEmpty(options.OutputPath))
+                {
+                    options.OutputPath = Path.Combine("generatedmaps", world.WorldName);
+                    Console.WriteLine($"Output folder not specified, defaulting to {options.OutputPath}");
+                }
+
+                if (!Directory.Exists(options.OutputPath))
+                {
+                    Directory.CreateDirectory(options.OutputPath);
+                }
 
                 // db stuff
                 var textures = ReadTerrainTextureJson();

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ For Linux: give the extracted PapyrusCs file execution rights! See installation 
   -w, --world                     Sets the path the Minecraft Bedrock Edition Map.  When not specified, searches 
                                   Bedrock Edition worlds folder and lets you chose from found worlds.
 
-  -o, --output                    (Default: generatedmap) Sets the output path for the generated map tiles
+  -o, --output                    (Default: generatedmaps/<world name>) Sets the output path for the generated map tiles
 
   --htmlfile                      (Default: map.html) Sets name of html map file
 


### PR DESCRIPTION
If an output folder is specified it will continue to render straight into that folder, with no world name subfolder.

But if nothing is specified it will default to generatedmaps/<world name>.