### PR TITLE
Fix for ArrayPool allocating buffers larger than requested

### DIFF
--- a/Maploader/World/SubChunkData.cs
+++ b/Maploader/World/SubChunkData.cs
@@ -7,6 +7,7 @@ namespace Maploader.World
     {
         public byte[] Key { get; set; }
         public byte[] Data { get; set; }
+        public int DataLength { get; set; }
         public UInt32 Crc32 { get; set; }
         public byte Index { get; set; }
         public bool FoundInDb { get; set; }

--- a/Maploader/World/World.cs
+++ b/Maploader/World/World.cs
@@ -47,16 +47,17 @@ namespace Maploader.World
             for (byte subChunkIdx = 0; subChunkIdx < 15; subChunkIdx++)
             {
                 key[9] = subChunkIdx;
-
-                var data = db.Get(key);
+                UIntPtr length;     
+                var data = db.Get(key, out length);
                 if (data != null)
                 {
                     var subChunkData = new SubChunkData()
                     {
                         Index = subChunkIdx,
                         Data = data,
+                        DataLength = (int)length,
                         Key = key,
-                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data)
+                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data, 0, (int)length)
                     };
                     ret.SubChunks.Add(subChunkData);
                 }
@@ -100,8 +101,8 @@ namespace Maploader.World
             for (byte subChunkIdx = 0; subChunkIdx < 15; subChunkIdx++)
             {
                 key[9] = subChunkIdx;
-
-                var data = db.Get(key);
+                UIntPtr length;
+                var data = db.Get(key, out length);
                 if (data != null)
                 {
                     subChunks[subChunkIdx] = data;
@@ -461,16 +462,17 @@ namespace Maploader.World
             foreach (var kvp in groupedChunkSubKeys.Subchunks)
             {
                 var key = kvp.Value;
-
-                var data = db.Get(key.Key);
+                UIntPtr length;
+                var data = db.Get(key.Key, out length);
                 if (data != null)
                 {
                     var subChunkData = new SubChunkData()
                     {
                         Index = kvp.Key,
                         Data = data,
+                        DataLength = (int)length,
                         Key = kvp.Value.Key,
-                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data),
+                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data, 0, (int)length),
                     };
                     ret.SubChunks.Add(subChunkData);
                 }
@@ -499,16 +501,17 @@ namespace Maploader.World
             foreach (var kvp in groupedChunkSubKeys)
             {
                 var key = kvp;
-
-                var data = db.Get(key.Key);
+                UIntPtr length;
+                var data = db.Get(key.Key, out length);
                 if (data != null)
                 {
                     var subChunkData = new SubChunkData()
                     {
                         Index = key.SubChunkId,
                         Data = data,
+                        DataLength = (int)length,
                         Key = key.Key,
-                       // Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data),
+                       // Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data, 0, (int)length),
                     };
                     ret.SubChunks.Add(subChunkData);
                 }
@@ -534,15 +537,17 @@ namespace Maploader.World
                 var key = CreateKey(x, z);
                 key[9] = (byte)kvp;
 
-                var data = db.Get(key);
+                UIntPtr length;
+                var data = db.Get(key, out length);
                 if (data != null)
                 {
                     var subChunkData = new SubChunkData()
                     {
                         Index = (byte)kvp,
                         Data = data,
+                        DataLength = (int)length,
                         Key = key,
-                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data),
+                        Crc32 = Force.Crc32.Crc32CAlgorithm.Compute(data, 0, (int)length),
                     };
                     ret.SubChunks.Add(subChunkData);
                 }

--- a/leveldb-sharp-std/DB.cs
+++ b/leveldb-sharp-std/DB.cs
@@ -62,7 +62,8 @@ namespace leveldb_sharp_std
 
         public byte[] this[byte[] key] {
             get {
-                return Get(null, key);
+                UIntPtr unusedLength;
+                return Get(null, key, out unusedLength);
             }
             set {
                 Put(null, key, value);
@@ -183,18 +184,18 @@ namespace leveldb_sharp_std
             Write(null, writeBatch);
         }
 
-        public byte[] Get(ReadOptions options, byte[] key)
+        public byte[] Get(ReadOptions options, byte[] key, out UIntPtr length)
         {
             CheckDisposed();
             if (options == null) {
                 options = new ReadOptions();
             }
-            return Native.leveldb_get(Handle, options.Handle, key);
+            return Native.leveldb_get(Handle, options.Handle, key, out length);
         }
 
-        public byte[] Get(byte[] key)
+        public byte[] Get(byte[] key, out UIntPtr length)
         {
-            return Get(null, key);
+            return Get(null, key, out length);
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/leveldb-sharp-std/Native.cs
+++ b/leveldb-sharp-std/Native.cs
@@ -196,7 +196,8 @@ namespace leveldb_sharp_std
 
         public static byte[] leveldb_get(IntPtr db,
                                          IntPtr readOptions,
-                                         byte[] key)
+                                         byte[] key,
+                                         out UIntPtr valueLength)
         {
            
 
@@ -204,7 +205,6 @@ namespace leveldb_sharp_std
             {
                 fixed (byte* p = key)
                 {
-                    UIntPtr valueLength;
                     string error;
                     var keyLength = (UIntPtr) key.Length;
                     IntPtr keyPtr = (IntPtr)p;


### PR DESCRIPTION
ArrayPool renting does not guarantee an exact size allocation. It can be bigger than requested.
It causes issues with CRC32 computation taking in the allocated buffer size rather than it's used length to compute CRC32.

This is my first foray into C#. I don't find it particularly elegant to have an out param on a "getter" but I don't see how I could get that data out while still using an ArrayPool allocation, which I think is the right thing to do here.

Anyway, now base zoom level rendering is now truly incremental. But I think there could be some more optimizations to speed up the process when no chunks needs rendering.

I think lower zoom level rendering could also be made incremental but a good strategy should be discussed before going in head down.