### PR TITLE
Player markers in multiple dimensions

### DIFF
--- a/PapyrusCs/map.thtml
+++ b/PapyrusCs/map.thtml
@@ -271,7 +271,7 @@
                     runtimeLayer.setVisible(
                       runtimeLayer.metaLayerKey == layerKey ||
                       runtimeLayer.metaLayerKey == "players_" + layerKey.substr(0, 4)
-                    ); // show image layer and player layers for the dimension
+                    ); // show image layer, and player layer based on dimension
                   });
 
                   const oldFocusGroup = currentSelectedLayer.substr(0, 4);
@@ -365,12 +365,13 @@
 
       if (typeof(playersData) !== "undefined") {
         var playerFeatures = [[], [], []];
+        // array for each dimension
+
         for (var playerIndex in playersData.players) {
             var player = playersData.players[playerIndex];
 
-            if (!player.visible) {
-                continue;
-            }
+            if (!player.visible) { continue; }
+            // hide players not visible
 
             var style = new ol.style.Style({
                 text: new ol.style.Text({
@@ -392,6 +393,7 @@
             playerFeature.setStyle(style);
 
             playerFeatures[player.dimensionId].push(playerFeature);
+            // add to the correct array/layer for the dimension
         }
 
         for (var dimensionId = 0; dimensionId < 3; dimensionId++) {
@@ -404,7 +406,12 @@
           });
 
           vectorLayer.metaLayerKey = "players_dim" + dimensionId;
-          if (dimensionId != 0) { vectorLayer.values_.visible = false; }
+
+          if (dimensionId != 0) {
+            // initially display only overworld players
+            vectorLayer.values_.visible = false;
+          }
+
           map.addLayer(vectorLayer);
         }
       }

--- a/PapyrusCs/map.thtml
+++ b/PapyrusCs/map.thtml
@@ -204,7 +204,7 @@
       } else {
         document.getElementById("map").style.background = "#202020";
       }
-                
+
       const view = new ol.View({
         projection: projection,
         center: [0, 0],
@@ -264,15 +264,16 @@
                 } else {
                   document.getElementById("map").style.background = "#202020";
                 }
-        
+
                 if (currentSelectedLayer != layerKey) {
                   const runtimeLayers = map.getLayers();
                   runtimeLayers.forEach(function(runtimeLayer) {
                     runtimeLayer.setVisible(
-                      runtimeLayer.metaLayerKey == layerKey
-                    );
+                      runtimeLayer.metaLayerKey == layerKey ||
+                      runtimeLayer.metaLayerKey == "players_" + layerKey.substr(0, 4)
+                    ); // show image layer and player layers for the dimension
                   });
-                  
+
                   const oldFocusGroup = currentSelectedLayer.substr(0, 4);
                   const newFocusGroup = layerKey.substr(0, 4);
 
@@ -363,20 +364,11 @@
       });
 
       if (typeof(playersData) !== "undefined") {
-        var playerFeatures = [];
-
-        for (var playerIndex in playersData.players)
-        {
+        var playerFeatures = [[], [], []];
+        for (var playerIndex in playersData.players) {
             var player = playersData.players[playerIndex];
 
             if (!player.visible) {
-                continue;
-            }
-
-            if (player.dimensionId !== 0) {
-                // TODO: Currently I'm only adding player markers who are in the Overworld
-                // We'll want to show players depending on which dimension is being viewed
-                // Maybe add a separate layer for players in each dimension
                 continue;
             }
 
@@ -399,18 +391,22 @@
 
             playerFeature.setStyle(style);
 
-            playerFeatures.push(playerFeature);
+            playerFeatures[player.dimensionId].push(playerFeature);
         }
 
-        var vectorSource = new ol.source.Vector({
-            features: playerFeatures
-        });
+        for (var dimensionId = 0; dimensionId < 3; dimensionId++) {
+          var vectorSource = new ol.source.Vector({
+              features: playerFeatures[dimensionId]
+          });
 
-        var vectorLayer = new ol.layer.Vector({
-            source: vectorSource
-        });
+          var vectorLayer = new ol.layer.Vector({
+              source: vectorSource
+          });
 
-        map.addLayer(vectorLayer);
+          vectorLayer.metaLayerKey = "players_dim" + dimensionId;
+          if (dimensionId != 0) { vectorLayer.values_.visible = false; }
+          map.addLayer(vectorLayer);
+        }
       }
     </script>
   </body>


### PR DESCRIPTION
This is an edit to render player markers in every dimension; it also fixes an issue where switching to another map/dimension and then back to the overworld causes all markers to disappear.

It does add markers to _every_ map of a given dimension, so that would include underground/aquatic maps as overworld maps with overworld player markers; this could be changed.